### PR TITLE
Add standard policy pages

### DIFF
--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -3,13 +3,28 @@ const today = new Date();
 ---
 
 <footer>
-	&copy; {today.getFullYear()} Clicktastic. All rights reserved.
+        <div class="links">
+                <a href="/privacy">Privacy Policy</a> |
+                <a href="/terms">Terms of Service</a>
+        </div>
+        &copy; {today.getFullYear()} Clicktastic. All rights reserved.
 </footer>
 <style>
-	footer {
-		padding: 2em 1em 6em 1em;
+        footer {
+                padding: 2em 1em 6em 1em;
 		background: linear-gradient(var(--gray-gradient)) no-repeat;
 		color: rgb(var(--gray));
-		text-align: center;
-	}
+                text-align: center;
+        }
+        .links {
+                margin-bottom: 0.5em;
+        }
+        .links a {
+                color: rgb(var(--gray));
+                text-decoration: none;
+                margin: 0 0.25em;
+        }
+        .links a:hover {
+                text-decoration: underline;
+        }
 </style>

--- a/src/pages/privacy.astro
+++ b/src/pages/privacy.astro
@@ -1,0 +1,23 @@
+---
+import Layout from '../layouts/BlogPost.astro';
+---
+
+<Layout
+        title="Privacy Policy"
+        description="How Clicktastic handles your information"
+        pubDate={new Date()}
+        heroImage="/blog-placeholder-2.jpg"
+>
+        <p>
+                We value your privacy. This policy explains what information we collect and how we use it.
+        </p>
+        <p>
+                We only collect personal details that you choose to provide when contacting us. This may include your name, email and any other information you submit through our forms.
+        </p>
+        <p>
+                We use this data solely to respond to inquiries and improve our services. We never sell your information and we maintain appropriate security measures to protect it.
+        </p>
+        <p>
+                By using this site you agree to the terms of this policy. If you have any questions, please <a href="/contact">contact us</a>.
+        </p>
+</Layout>

--- a/src/pages/terms.astro
+++ b/src/pages/terms.astro
@@ -1,0 +1,20 @@
+---
+import Layout from '../layouts/BlogPost.astro';
+---
+
+<Layout
+        title="Terms of Service"
+        description="The rules for using Clicktastic"
+        pubDate={new Date()}
+        heroImage="/blog-placeholder-5.jpg"
+>
+        <p>
+                By accessing this website you agree to comply with these terms. All content is provided for general information and may change without notice.
+        </p>
+        <p>
+                Unauthorized use of any material on this site may give rise to a claim for damages. Links to other websites are provided for convenience and do not signify endorsement.
+        </p>
+        <p>
+                We reserve the right to update these terms at any time. Your continued use of the site constitutes acceptance of any changes.
+        </p>
+</Layout>


### PR DESCRIPTION
## Summary
- add Privacy Policy and Terms of Service pages
- link to them from the footer

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_686ea76d02c0832b92ba1f4419e04b74